### PR TITLE
Fix issue with systems that does not have /etc/init.d/tor

### DIFF
--- a/lib/Nipe/Stop.pm
+++ b/lib/Nipe/Stop.pm
@@ -9,9 +9,13 @@ sub new {
 		system ("sudo iptables -t $table -F OUTPUT");
 		system ("sudo iptables -t $table -F OUTPUT");
 	}
-
-	system("sudo /etc/init.d/tor stop > /dev/null");
-
+	
+	if ( -e "/etc/init.d/tor") {
+		system ("sudo /etc/init.d/tor stop > /dev/null");
+	} else { 
+		system ("sudo systemctl stop tor");
+	}
+	
 	return true;
 }
 


### PR DESCRIPTION
### What was a problem?

The script fails if /etc/init.d/ doesn't exist.

### How this PR fixes the problem?

Using systemd if the /etc/init.d/ path is not available.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)

