### PR TITLE
Fix issue with systems that does not have /etc/init.d/tor

### DIFF
--- a/lib/Nipe/Start.pm
+++ b/lib/Nipe/Start.pm
@@ -57,8 +57,11 @@ sub new {
 
 	system ("sudo iptables -t filter -A OUTPUT -p udp -j REJECT");
 	system ("sudo iptables -t filter -A OUTPUT -p icmp -j REJECT");
-	system ("sudo /etc/init.d/tor start > /dev/null");
-
+	if ( -e "/etc/init.d/tor") {
+		system ("sudo /etc/init.d/tor start > /dev/null");
+	} else { 
+		system ("sudo systemctl start tor");
+	}
 	return true;
 }
 


### PR DESCRIPTION
### What was a problem?

The script fails if /etc/init.d/ not exist in the system

### How this PR fixes the problem?

Using systemd if the /etc/init.d/ path is not available.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)

